### PR TITLE
[BUGFIX] Skip over pseudo-patterns when exporting.

### DIFF
--- a/src/FluidPatternLabHook.php
+++ b/src/FluidPatternLabHook.php
@@ -51,6 +51,10 @@ class FluidPatternLabHook
         $parser = $this->view->getRenderingContext()->getTemplateParser();
 
         foreach ($filtered as $patternName => $patternConfiguration) {
+            if (array_key_exists('pseudo', $patternConfiguration) && $patternConfiguration['pseudo']) {
+                continue;
+            }
+
             $targetFilename = $helper->determineTargetFileLocationForPattern($patternName);
             $sourceFilename = $this->determineSourceFileLocation($patternConfiguration, $types);
             if (!file_exists($sourceFilename)) {


### PR DESCRIPTION
Pattern Lab has the idea of pseudo-patterns which are just alternate data files (JSON or YAML) that still use the same underlying HTML.  For example, a logged in state vs. not logged in.  See http://patternlab.io/docs/pattern-pseudo-patterns.html

When exporting, we should just skip over these pseudo-patterns because they are really just data files.  The logic for them is embedded in a template we're already exporting.